### PR TITLE
Changed default compiler to clang

### DIFF
--- a/src/indirect_compiler.sh
+++ b/src/indirect_compiler.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#Debug options
+DEBUG_VERBOSE_MODE=false
+
+#ARGS will contain the full modified command & argument list to call
+CMD=""
+
+#Loop through passed arguments and strip out problematic arguments
+for var in "$@"
+do
+	if [ "$var" != "-fexec-charset=UTF-8" ]; then
+		CMD="$CMD $var"
+	fi
+done
+
+#Additional output in verbose mode
+if [ "$DEBUG_VERBOSE_MODE" = true ]; then
+	echo "[DEBUG] Running: $CMD"
+fi
+
+#Execute modified argument list
+$CMD

--- a/src/indirect_compiler.sh
+++ b/src/indirect_compiler.sh
@@ -1,3 +1,27 @@
+# indirect_compiler.sh
+# This file is part of CoreGTK
+#
+# Copyright (C) 2015 - Tyler Burton
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#
+#
+# Modified by the CoreGTK Team, 2015. See the AUTHORS file for a
+# list of people on the CoreGTK Team.
+# See the ChangeLog files for a list of changes.
+
 #!/bin/bash
 
 #Debug options

--- a/src/main.m
+++ b/src/main.m
@@ -1,6 +1,6 @@
 /*
  * main.m
- * This file is part of CoreGTKGen
+ * This file is part of CoreGTK
  *
  * Copyright (C) 2015 - Tyler Burton
  *

--- a/src/makefile
+++ b/src/makefile
@@ -7,26 +7,29 @@ SOURCES=main.m CoreGTK/CGTK.m CoreGTK/CGTKBase.m CoreGTK/CGTKBaseBuilder.m CoreG
 #Objects
 OBJECTS=$(SOURCES:.m=.o)
 
-#compiler
-CC=gcc
+#Indirect compiler for fixing GNUstep/clang argument bug 
+ICC=./indirect_compiler.sh
+
+#Compiler
+CC=clang
+
+#Compiler flags
+CCFLAGS=-Qunused-arguments -Wno-deprecated-declarations
 
 #CFLAGS
-CFLAGS=-c -Wno-deprecated-declarations -Wno-deprecated
-
-#Objective-c specific flags
-OBJCFLAGS=`gnustep-config --objc-flags` `pkg-config --cflags gtk+-3.0`
+CFLAGS=-c
 
 #Objective-c specific flags
 MACOBJCFLAGS=-framework Foundation
 
 #GNUstep dependencies
-GNUSTEPDEPS=`gnustep-config --base-libs`
+GNUSTEPDEPS=`gnustep-config --objc-flags` `gnustep-config --base-libs`
 
 #GTK dependencies
-GTKDEPS=`pkg-config --libs gtk+-3.0`
+GTKDEPS=`pkg-config --cflags gtk+-3.0` `pkg-config --libs gtk+-3.0`
 
 #Common flags
-COMMONFLAGS=$(OBJCFLAGS) $(GNUSTEPDEPS) $(GTKDEPS)
+COMMONFLAGS=$(CCFLAGS) $(GNUSTEPDEPS) $(GTKDEPS)
 
 
 #Targets
@@ -35,7 +38,7 @@ COMMONFLAGS=$(OBJCFLAGS) $(GNUSTEPDEPS) $(GTKDEPS)
 linux: all
 
 #Mac Target
-mac: COMMONFLAGS=$(MACOBJCFLAGS) $(GTKDEPS)
+mac: COMMONFLAGS=$(CCFLAGS) $(MACOBJCFLAGS) $(GTKDEPS)
 mac: all
 
 #Windows Target
@@ -45,10 +48,10 @@ windows: all
 all: $(SOURCES) $(EXECUTABLE)
 
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(OBJECTS) $(COMMONFLAGS) -o $@
+	$(ICC) $(CC) $(OBJECTS) $(COMMONFLAGS) -o $@
 
 %.o: %.m
-	$(CC) $(CFLAGS) $(COMMONFLAGS) $< -o $@
+	$(ICC) $(CC) $(CFLAGS) $(COMMONFLAGS) $< -o $@
 
 clean: 
 	rm -rf *.o *.d $(EXECUTABLE)


### PR DESCRIPTION
-Changed default compiler to clang.
-Added indirect_compiler.sh script to strip out "-fexec-charset=UTF-8" generated from "gnustep-config --objc-flags" before passing it to clang. Clang errors on this argument so it must be removed before invoking the compiler. There is probably a better way to do this but for now this will work.
-Cleaned up makefile.
-Documentation fixes.