### PR TITLE
Fixed OS X compile error

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -14,7 +14,7 @@ ICC=./indirect_compiler.sh
 CC=clang
 
 #Compiler flags
-CCFLAGS=-Qunused-arguments -Wno-deprecated-declarations
+CCFLAGS=-Qunused-arguments -Wno-deprecated-declarations -I. -I./CoreGTK
 
 #CFLAGS
 CFLAGS=-c


### PR DESCRIPTION
Added missing includes to makefile so that it would successfully compile on OS X again. Fixes issue #22.